### PR TITLE
Improve DimensionId

### DIFF
--- a/src/amulet/level/abc/chunk_handle.cpp
+++ b/src/amulet/level/abc/chunk_handle.cpp
@@ -31,7 +31,7 @@ namespace detail {
 } // namespace detail
 
 ChunkHandle::ChunkHandle(
-    const DimensionID& dimension_id,
+    const DimensionId& dimension_id,
     std::int64_t cx,
     std::int64_t cz)
     : _dimension_id(dimension_id)

--- a/src/amulet/level/abc/chunk_handle.hpp
+++ b/src/amulet/level/abc/chunk_handle.hpp
@@ -13,7 +13,7 @@
 
 namespace Amulet {
 
-using DimensionID = std::string;
+using DimensionId = std::string;
 
 namespace detail {
 
@@ -44,7 +44,7 @@ protected:
     std::int64_t _cz;
     detail::ChunkKey _key;
 
-    ChunkHandle(const DimensionID& dimension_id, std::int64_t cx, std::int64_t cz);
+    ChunkHandle(const DimensionId& dimension_id, std::int64_t cx, std::int64_t cz);
 
 public:
     ChunkHandle() = delete;

--- a/src/amulet/level/abc/dimension.hpp
+++ b/src/amulet/level/abc/dimension.hpp
@@ -13,7 +13,7 @@
 
 namespace Amulet {
 
-using DimensionID = std::string;
+using DimensionId = std::string;
 
 class Dimension {
 public:
@@ -22,7 +22,7 @@ public:
 
     // Get the dimension id for this dimension.
     // Thread safe.
-    virtual const DimensionID& get_dimension_id() const = 0;
+    virtual const DimensionId& get_dimension_id() const = 0;
 
     // The editable region of the dimension.
     // Thread safe.

--- a/src/amulet/level/abc/dimension.py.cpp
+++ b/src/amulet/level/abc/dimension.py.cpp
@@ -11,6 +11,8 @@ py::module init_dimension(py::module m_parent)
 {
     auto m = m_parent.def_submodule("dimension");
 
+    m.attr("DimensionId") = py::module::import("builtins").attr("str");
+
     py::class_<Amulet::Dimension, std::shared_ptr<Amulet::Dimension>> Dimension(m, "Dimension");
     Dimension.def_property_readonly(
         "dimension_id",

--- a/src/amulet/level/abc/dimension.pyi
+++ b/src/amulet/level/abc/dimension.pyi
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+from builtins import str as DimensionId
+
 import amulet.core.biome
 import amulet.core.block
 import amulet.core.selection.box
 import amulet.core.selection.group
 import amulet.level.abc.chunk_handle
 
-__all__ = ["Dimension"]
+__all__ = ["Dimension", "DimensionId"]
 
 class Dimension:
     def get_chunk_handle(

--- a/src/amulet/level/java/chunk_handle.cpp
+++ b/src/amulet/level/java/chunk_handle.cpp
@@ -8,7 +8,7 @@
 namespace Amulet {
 
 JavaChunkHandle::JavaChunkHandle(
-    const DimensionID& dimension_id,
+    const DimensionId& dimension_id,
     std::int64_t cx,
     std::int64_t cz,
     std::shared_ptr<JavaRawDimension> raw_dimension,

--- a/src/amulet/level/java/chunk_handle.hpp
+++ b/src/amulet/level/java/chunk_handle.hpp
@@ -22,7 +22,7 @@ private:
     std::shared_ptr<bool> _history_enabled;
 
     JavaChunkHandle(
-        const DimensionID& dimension_id,
+        const DimensionId& dimension_id,
         std::int64_t cx,
         std::int64_t cz,
         std::shared_ptr<JavaRawDimension> raw_dimension,

--- a/src/amulet/level/java/dimension.cpp
+++ b/src/amulet/level/java/dimension.cpp
@@ -18,7 +18,7 @@ JavaDimension::~JavaDimension()
 {
 }
 
-const DimensionID& JavaDimension::get_dimension_id() const
+const DimensionId& JavaDimension::get_dimension_id() const
 {
     return _raw_dimension->get_dimension_id();
 }

--- a/src/amulet/level/java/dimension.hpp
+++ b/src/amulet/level/java/dimension.hpp
@@ -39,7 +39,7 @@ public:
 
     // Get the dimension id for this dimension.
     // Thread safe.
-    AMULET_LEVEL_EXPORT const DimensionID& get_dimension_id() const override;
+    AMULET_LEVEL_EXPORT const DimensionId& get_dimension_id() const override;
 
     // The editable region of the dimension.
     // Thread safe.

--- a/src/amulet/level/java/level.cpp
+++ b/src/amulet/level/java/level.cpp
@@ -194,7 +194,7 @@ std::vector<std::string> JavaLevel::get_dimension_ids()
     return _raw_level->get_dimension_ids();
 }
 
-std::shared_ptr<JavaDimension> JavaLevel::get_java_dimension(const DimensionID& dimension_id)
+std::shared_ptr<JavaDimension> JavaLevel::get_java_dimension(const DimensionId& dimension_id)
 {
     auto& open_data = _get_open_data();
     {
@@ -227,7 +227,7 @@ std::shared_ptr<JavaDimension> JavaLevel::get_java_dimension(const DimensionID& 
     }
 }
 
-std::shared_ptr<Dimension> JavaLevel::get_dimension(const DimensionID& dimension_id)
+std::shared_ptr<Dimension> JavaLevel::get_dimension(const DimensionId& dimension_id)
 {
     return get_java_dimension(dimension_id);
 }

--- a/src/amulet/level/java/level.hpp
+++ b/src/amulet/level/java/level.hpp
@@ -21,7 +21,7 @@ public:
     HistoryManager history_manager;
     std::shared_ptr<bool> history_enabled;
     std::shared_mutex dimensions_mutex;
-    std::map<DimensionID, std::shared_ptr<JavaDimension>> dimensions;
+    std::map<DimensionId, std::shared_ptr<JavaDimension>> dimensions;
 
     JavaLevelOpenData();
 };
@@ -165,12 +165,12 @@ public:
     // Get a dimension.
     // External Read:SharedReadWrite lock required.
     // External ReadWrite:SharedReadWrite lock required when calling code in Dimension (and its children) that need write permission.
-    AMULET_LEVEL_EXPORT std::shared_ptr<JavaDimension> get_java_dimension(const DimensionID&);
+    AMULET_LEVEL_EXPORT std::shared_ptr<JavaDimension> get_java_dimension(const DimensionId&);
 
     // Get a dimension.
     // External Read:SharedReadWrite lock required.
     // External ReadWrite:SharedReadWrite lock required when calling code in Dimension (and its children) that need write permission.
-    AMULET_LEVEL_EXPORT std::shared_ptr<Dimension> get_dimension(const DimensionID&) override;
+    AMULET_LEVEL_EXPORT std::shared_ptr<Dimension> get_dimension(const DimensionId&) override;
 
     // CompactibleLevel
 

--- a/src/amulet/level/java/raw_dimension.cpp
+++ b/src/amulet/level/java/raw_dimension.cpp
@@ -15,7 +15,7 @@ OrderedMutex& JavaRawDimension::get_mutex()
     return _public_mutex;
 }
 
-const DimensionID& JavaRawDimension::get_dimension_id() const
+const DimensionId& JavaRawDimension::get_dimension_id() const
 {
     return _dimension_id;
 }

--- a/src/amulet/level/java/raw_dimension.hpp
+++ b/src/amulet/level/java/raw_dimension.hpp
@@ -31,7 +31,7 @@ private:
     OrderedMutex _public_mutex;
     AnvilDimension _anvil_dimension;
     JavaInternalDimensionID _relative_path;
-    DimensionID _dimension_id;
+    DimensionId _dimension_id;
     SelectionBox _bounds;
     BlockStack _default_block;
     Biome _default_biome;
@@ -43,7 +43,7 @@ private:
         bool mcc,
         const layersT& layers,
         const JavaInternalDimensionID& relative_path,
-        const DimensionID& dimension_id,
+        const DimensionId& dimension_id,
         const SelectionBox& bounds,
         const BlockStack& default_block,
         const Biome& default_biome)
@@ -77,7 +77,7 @@ public:
 
     // The identifier for this dimension. eg. "minecraft:overworld".
     // Thread safe.
-    AMULET_LEVEL_EXPORT const DimensionID& get_dimension_id() const;
+    AMULET_LEVEL_EXPORT const DimensionId& get_dimension_id() const;
 
     // The relative path to the dimension. eg. "DIM1".
     // Thread safe.

--- a/src/amulet/level/java/raw_level.cpp
+++ b/src/amulet/level/java/raw_level.cpp
@@ -335,7 +335,7 @@ void JavaRawLevel::set_level_name(const std::string& level_name)
 
 static const SelectionBox DefaultSelection { -30'000'000, 0, -30'000'000, 60'000'000, 256, 60'000'000 };
 
-SelectionBox JavaRawLevel::_get_dimension_bounds(const DimensionID& dimension_id)
+SelectionBox JavaRawLevel::_get_dimension_bounds(const DimensionId& dimension_id)
 {
     if (_data_version < VersionNumber { 2709 }) {
         // Old versions were hard coded.
@@ -457,7 +457,7 @@ SelectionBox JavaRawLevel::_get_dimension_bounds(const DimensionID& dimension_id
 void JavaRawLevel::_register_dimension(
     JavaRawLevelOpenData& raw_open,
     const JavaInternalDimensionID& relative_dimension_path,
-    const DimensionID& dimension_id)
+    const DimensionId& dimension_id)
 {
     if (!raw_open.dimension_ids.contains(dimension_id) && !raw_open.dimensions.contains(relative_dimension_path)) {
         // Get the dimension path
@@ -580,7 +580,7 @@ std::vector<std::string> JavaRawLevel::get_dimension_ids()
 {
     auto& raw_open = _find_dimensions();
     std::shared_lock lock(raw_open.dimensions_mutex);
-    std::vector<DimensionID> dimension_ids;
+    std::vector<DimensionId> dimension_ids;
     dimension_ids.reserve(raw_open.dimension_ids.size());
     for (auto& [dimension_id, _] : raw_open.dimension_ids) {
         dimension_ids.push_back(dimension_id);
@@ -588,7 +588,7 @@ std::vector<std::string> JavaRawLevel::get_dimension_ids()
     return dimension_ids;
 }
 
-std::shared_ptr<JavaRawDimension> JavaRawLevel::get_dimension(const DimensionID& dimension_id)
+std::shared_ptr<JavaRawDimension> JavaRawLevel::get_dimension(const DimensionId& dimension_id)
 {
     auto& raw_open = _find_dimensions();
     std::shared_lock lock(raw_open.dimensions_mutex);

--- a/src/amulet/level/java/raw_level.hpp
+++ b/src/amulet/level/java/raw_level.hpp
@@ -52,7 +52,7 @@ public:
     // TODO: data_pack
     std::shared_mutex dimensions_mutex;
     std::map<JavaInternalDimensionID, std::shared_ptr<JavaRawDimension>> dimensions;
-    std::map<DimensionID, JavaInternalDimensionID> dimension_ids;
+    std::map<DimensionId, JavaInternalDimensionID> dimension_ids;
     std::shared_ptr<IdRegistry> block_id_override;
     std::shared_ptr<IdRegistry> biome_id_override;
 
@@ -99,11 +99,11 @@ private:
     std::unique_ptr<LockFile> _close();
     VersionNumber _get_data_version();
 
-    SelectionBox _get_dimension_bounds(const DimensionID&);
+    SelectionBox _get_dimension_bounds(const DimensionId&);
 
     // Register a dimension
     // Must be called with the dimension lock in unique mode.
-    void _register_dimension(JavaRawLevelOpenData&, const JavaInternalDimensionID&, const DimensionID&);
+    void _register_dimension(JavaRawLevelOpenData&, const JavaInternalDimensionID&, const DimensionId&);
 
 public:
     JavaRawLevel() = delete;
@@ -212,7 +212,7 @@ public:
 
     // Get the raw dimension object for a specific dimension.
     // External Read:SharedReadWrite lock required.
-    AMULET_LEVEL_EXPORT std::shared_ptr<JavaRawDimension> get_dimension(const DimensionID&);
+    AMULET_LEVEL_EXPORT std::shared_ptr<JavaRawDimension> get_dimension(const DimensionId&);
 
     // Compact the level.
     // External Read:SharedReadWrite lock required.


### PR DESCRIPTION
Rename DimensionID to DimensionId to match CamelCase convention.
Add DimensionId to the python interface.